### PR TITLE
Potential fix for code scanning alert no. 292: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -1,5 +1,7 @@
 ---
     name: Rust Continuous Integration
+    permissions:
+      contents: read
     
     #######################################
     # Start the job on all push to master #


### PR DESCRIPTION
Potential fix for [https://github.com/IvanKuchin/ftd-acl-optimizer/security/code-scanning/292](https://github.com/IvanKuchin/ftd-acl-optimizer/security/code-scanning/292)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will explicitly set the permissions to `contents: read`, which is sufficient for the operations performed in this workflow. This ensures that the workflow does not inadvertently gain unnecessary write permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
